### PR TITLE
Update to guzzle 7 so laravel 8 is supported

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require-dev": {
         "phpunit/phpunit": "^5.7",
         "fzaninotto/faker": "^1.6",
-        "satooshi/php-coveralls": "^2.0"
+        "php-coveralls/php-coveralls": "^2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "LGPL-3.0-only",
     "require": {
         "php": ">=5.5.9",
-        "guzzlehttp/guzzle": "~6.0",
+        "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "fzaninotto/faker": "^1.6"
     },
     "require-dev": {


### PR DESCRIPTION
# Why
This allows guzzle 7.0, which in turn allows this package to be used on Laravel 8+ projects.

I've also switched from the `satooshi/php-coveralls` package to the default `php-coveralls/php-coveralls` package as the former was no longer maintained and also hard required guzzle ~6.0. As far as I can tell, the configs of both were the same, but please let me know if this change affects anything @DivineOmega 